### PR TITLE
Make compatible with python3 venv module

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015 Jan Gosmann
+Copyright (c) 2019 Federico Jaramillo
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -1,17 +1,63 @@
+"""
+Activate a virtual environment from Python.
+
+Activation logic taken from https://github.com/pypa/virtualenv
+"""
+
 import os
+import site
+import sys
+
+
+def is_venv():
+    """Return true if a virtual environment is active."""
+    return getattr(sys, "base_prefix", sys.prefix) != sys.prefix or hasattr(
+        sys, "real_prefix"
+    )
+
+
+def activate_venv(active_site, venv=None):
+    """
+    Search and activate a Virtual Environment.
+
+    Activate the virtual environment from:
+    - The `venv` param, if one is given.
+    - `VIRTUAL_ENV` environmental variable if set.
+    - a `.venv` folder in the current working directory
+    """
+    if venv is None:
+        venv = os.environ.get("VIRTUAL_ENV", None)
+
+    if venv is None:
+        cwd = os.getcwd()
+        exec_path = 'Scripts' if sys.platform == "win32" else 'bin'
+        if os.path.isfile(os.path.join(cwd, ".venv", exec_path, "activate")):
+            venv = os.path.join(cwd, ".venv")
+
+    if venv is not None:
+        os.environ["VIRTUAL_ENV"] = venv
+        os.environ["PATH"] = (
+            os.path.join(venv, "bin") + os.pathsep + os.environ.get("PATH", "")
+        )
+        base = venv
+        if sys.platform == "win32":
+            site_packages = os.path.join(base, "Lib", "site-packages")
+        else:
+            site_packages = os.path.join(
+                base, "lib", "python%s" % sys.version[:3], "site-packages"
+            )
+
+        prev = set(sys.path)
+        active_site.addsitedir(site_packages)
+        sys.real_prefix = sys.prefix
+        sys.prefix = base
+
+        # Move the added items to the front of the path, in place
+        new = list(sys.path)
+        sys.path[:] = [i for i in new if i not in prev] + [i for i in new if i in prev]
 
 
 def inithook(venv=None):
-    if venv is None:
-        venv = os.environ.get('VIRTUAL_ENV', None)
-
-    if venv is not None:
-        activate_script = os.path.join(venv, 'bin', 'activate_this.py')
-        if not os.path.exists(activate_script):
-            activate_script = os.path.join(venv, 'Scripts', 'activate_this.py')
-
-        with open(activate_script, 'r') as f:
-            source = f.read()
-        exec(
-            compile(source, activate_script, 'exec'),
-            dict(__file__=activate_script))
+    """Activate a Virtual Environment if one is not active."""
+    if not is_venv():
+        activate_venv(site, venv)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as f:
 
 setup(
     name='pylint-venv',
-    version='2.0.0.dev0',
+    version='1.1.0',
     description='pylint-venv provides a Pylint init-hook to use the same '
     'Pylint installation with different virtual environments.',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,12 @@ with open('README.rst') as f:
 
 setup(
     name='pylint-venv',
-    version='1.0',
+    version='2.0.0.dev0',
     description='pylint-venv provides a Pylint init-hook to use the same '
     'Pylint installation with different virtual environments.',
     long_description=long_description,
-    author='Jan Gosmann',
-    author_email='jan@hyper-world.de',
+    author='Jan Gosmann, Federico Jaramillo',
+    author_email='jan@hyper-world.de, federicojaramillom@gmail.com',
     url='https://github.com/jgosmann/pylint-venv/',
     py_modules=['pylint_venv'],
     provides=['pylint_venv'],


### PR DESCRIPTION
I took the code that [virtualenv](https://github.com/pypa/virtualenv) uses to activate a virtual environment from within python itself, and implemented it directly in this module.

This allows us to activate virtual environments from both [virtualenv](https://github.com/pypa/virtualenv) and the [venv](https://docs.python.org/3/library/venv.html) python3 module.

Also added a check to not activate a virtual environment if one is already active.