### PR TITLE
Add support for Conda and PyPy, improve docs and readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+*.egg-info/
+*.pyc
+.DS_Store
+MANIFEST
 build
 dist
-*.pyc
-MANIFEST

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ pylint-venv
 ===========
 
 Pylint_ does not respect the currently activated virtualenv_ if it is not
-installed in every virtual environment individually. This module provides
+installed in every virtual environment individually.  This module provides
 a Pylint init-hook to use the same Pylint installation with different virtual
 environments.
 
@@ -17,9 +17,19 @@ Add the following to your ``~/.pylintrc``:
 
 .. code:: ini
 
-    init-hook="
-        from pylint_venv import inithook
-        inithook()"
+    init-hook=
+        try: import pylint_venv
+        except ImportError: pass
+        else: pylint_venv.inithook()
+
+
+You can also call the hook via a command line argument.  This way you can also
+pass an explicit env. to use:
+
+.. code:: console
+
+    $ pylint --init-hook="import pylint_venv; pylint_venv.inithook()"
+    $ pylint --init-hook="import pylint_venv; pylint_venv.inithook('$(pwd)/env')"
 
 .. _Pylint: http://www.pylint.org/
 .. _virtualenv: https://virtualenv.pypa.io/en/latest/

--- a/README.rst
+++ b/README.rst
@@ -22,13 +22,26 @@ Add the following to your ``~/.pylintrc``:
         except ImportError: pass
         else: pylint_venv.inithook()
 
+The hook will then be used automatically if
 
-You can also call the hook via a command line argument.  This way you can also
-pass an explicit env. to use:
+- a virtualenv is activated
+
+- a Conda environment is activated
+
+- no env is activated but your CWD contains a virtualenv in ``.venv``
+
+and if pylint is not installed in that env, too.
+
+You can also call the hook via a command line argument:
 
 .. code:: console
 
     $ pylint --init-hook="import pylint_venv; pylint_venv.inithook()"
+
+This way you can also explicitly set an environment to be used:
+
+.. code:: console
+
     $ pylint --init-hook="import pylint_venv; pylint_venv.inithook('$(pwd)/env')"
 
 .. _Pylint: http://www.pylint.org/

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -16,7 +16,7 @@ def is_venv():
     return is_conda_env or is_virtualenv
 
 
-def activate_venv(active_site, venv=None):
+def activate_venv(venv=None):
     """
     Search and activate a Virtual Environment.
 
@@ -48,11 +48,11 @@ def activate_venv(active_site, venv=None):
             )
 
         prev = set(sys.path)
-        active_site.addsitedir(site_packages)
+        site.addsitedir(site_packages)
         sys.real_prefix = sys.prefix
         sys.prefix = base
 
-        # Move the added items to the front of the path, in place
+        # Move the added items to the front of sys.path (in place!)
         new = list(sys.path)
         sys.path[:] = [i for i in new if i not in prev] + [i for i in new if i in prev]
 
@@ -63,4 +63,4 @@ def inithook(venv=None):
         # pylint was invoked from within a venv.  Nothing to do.
         return
 
-    activate_venv(site, venv)
+    activate_venv(venv)

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -11,14 +11,34 @@ folder, activate that env and add its paths to Pylint.
 Do nothing if no virtualenv is active or if Pylint is installed within the
 active virtualenv.
 
-
 Activation logic taken from https://github.com/pypa/virtualenv
+
+Usage:
+
+- Add an init hook to your ``.pylintrc``::
+    init-hook=
+        try: import pylint_venv
+        except ImportError: pass
+        else: pylint_venv.inithook()
+
+- Add the init hook as command line argument::
+
+    pylint --init-hook="import pylint_venv; pylint_venv.inithook()"
+
+- Add the init hook as command line argument and explicitly pass a venv::
+
+    pylint --init-hook="import pylint_venv; pylint_venv.inithook('$(pwd)/env')"
 
 """
 
 import os
+import platform
 import site
 import sys
+
+
+IS_WIN = platform.system() == "Windows"
+IS_PYPY = platform.python_implementation() == "PyPy"
 
 
 def is_venv():
@@ -31,7 +51,23 @@ def is_venv():
     return is_conda_env or is_virtualenv
 
 
-def activate_venv(venv=None):
+def detect_venv():
+    # Check for a virtualenv or Conda env
+    for var in ["VIRTUAL_ENV", "CONDA_PREFIX"]:
+        venv = os.getenv(var, "")
+        if venv:
+            return venv
+
+    # Check if a local ".venv" folder exists
+    cwd = os.getcwd()
+    exec_path = "Scripts" if IS_WIN else "bin"
+    if os.path.isfile(os.path.join(cwd, ".venv", exec_path, "activate")):
+        return os.path.join(cwd, ".venv")
+
+    return None
+
+
+def activate_venv(venv):
     """Check for an active venv and add its paths to Pylint.
 
     Activate the virtual environment from:
@@ -41,36 +77,23 @@ def activate_venv(venv=None):
     - A ``.venv`` folder in the current working directory
 
     """
-    if venv is None:
-        venv = os.environ.get("VIRTUAL_ENV", None)
-
-    if venv is None:
-        cwd = os.getcwd()
-        exec_path = 'Scripts' if sys.platform == "win32" else 'bin'
-        if os.path.isfile(os.path.join(cwd, ".venv", exec_path, "activate")):
-            venv = os.path.join(cwd, ".venv")
-
-    if venv is not None:
-        os.environ["VIRTUAL_ENV"] = venv
-        os.environ["PATH"] = (
-            os.path.join(venv, "bin") + os.pathsep + os.environ.get("PATH", "")
-        )
-        base = venv
-        if sys.platform == "win32":
-            site_packages = os.path.join(base, "Lib", "site-packages")
+    if IS_PYPY:
+        site_packages = os.path.join(venv, "site-packages")
+    else:
+        if IS_WIN:
+            site_packages = os.path.join(venv, "Lib", "site-packages")
         else:
-            site_packages = os.path.join(
-                base, "lib", "python%s" % sys.version[:3], "site-packages"
-            )
+            pyver = f"{sys.version_info[0]}.{sys.version_info[1]}"
+            site_packages = os.path.join(venv, "lib", f"python{pyver}", "site-packages")
 
-        prev = set(sys.path)
-        site.addsitedir(site_packages)
-        sys.real_prefix = sys.prefix
-        sys.prefix = base
+    prev = set(sys.path)
+    site.addsitedir(site_packages)
+    sys.real_prefix = sys.prefix
+    sys.prefix = venv
 
-        # Move the added items to the front of sys.path (in place!)
-        new = list(sys.path)
-        sys.path[:] = [i for i in new if i not in prev] + [i for i in new if i in prev]
+    # Move the added items to the front of sys.path (in place!)
+    new = list(sys.path)
+    sys.path[:] = [i for i in new if i not in prev] + [i for i in new if i in prev]
 
 
 def inithook(venv=None):
@@ -83,4 +106,11 @@ def inithook(venv=None):
         # pylint was invoked from within a venv.  Nothing to do.
         return
 
+    if venv is None:
+        venv = detect_venv()
+
+    if venv is None:
+        return
+
+    print(f"\033[1;33mUsing env: {venv}\033[0m", file=sys.stderr)
     activate_venv(venv)

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -113,5 +113,5 @@ def inithook(venv=None):
     if venv is None:
         return
 
-    print(f"\033[1;33mUsing env: {venv}\033[0m", file=sys.stderr)
+    print(f"Using env: {venv}", file=sys.stderr)
     activate_venv(venv)

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -1,7 +1,19 @@
 """
-Activate a virtual environment from Python.
+Allow a globally installed Pylint to lint an (active) virtual or Conda
+environment.
+
+If a globally installed Pylint is invoked from an active virtualenv or Conda
+environment, add the environment's paths to Pylint.
+
+If no virtualenv is active but the CWD contains a virtualenv in a  ``.venv``
+folder, activate that env and add its paths to Pylint.
+
+Do nothing if no virtualenv is active or if Pylint is installed within the
+active virtualenv.
+
 
 Activation logic taken from https://github.com/pypa/virtualenv
+
 """
 
 import os
@@ -10,20 +22,24 @@ import sys
 
 
 def is_venv():
-    """Return true if a virtual environment is active."""
+    """Return ``true`` if a virtual environment is active and Pylint is
+    installed in it.
+
+    """
     is_conda_env = getattr(sys, "base_prefix", sys.prefix) != sys.prefix
     is_virtualenv = hasattr(sys, "real_prefix")
     return is_conda_env or is_virtualenv
 
 
 def activate_venv(venv=None):
-    """
-    Search and activate a Virtual Environment.
+    """Check for an active venv and add its paths to Pylint.
 
     Activate the virtual environment from:
-    - The `venv` param, if one is given.
-    - `VIRTUAL_ENV` environmental variable if set.
-    - a `.venv` folder in the current working directory
+
+    - The *venv* param if one is given.
+    - ``VIRTUAL_ENV`` environmental variable if set.
+    - A ``.venv`` folder in the current working directory
+
     """
     if venv is None:
         venv = os.environ.get("VIRTUAL_ENV", None)
@@ -58,7 +74,11 @@ def activate_venv(venv=None):
 
 
 def inithook(venv=None):
-    """Activate a Virtual Environment if one is not active."""
+    """Add a virtualenv's paths to Pylint.
+
+    Use the environment *env* if set or auto-detect an active virtualenv.
+
+    """
     if is_venv():
         # pylint was invoked from within a venv.  Nothing to do.
         return

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -79,12 +79,11 @@ def activate_venv(venv):
     """
     if IS_PYPY:
         site_packages = os.path.join(venv, "site-packages")
+    elif IS_WIN:
+        site_packages = os.path.join(venv, "Lib", "site-packages")
     else:
-        if IS_WIN:
-            site_packages = os.path.join(venv, "Lib", "site-packages")
-        else:
-            pyver = f"{sys.version_info[0]}.{sys.version_info[1]}"
-            site_packages = os.path.join(venv, "lib", f"python{pyver}", "site-packages")
+        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+        site_packages = os.path.join(venv, "lib", pyver, "site-packages")
 
     prev = set(sys.path)
     site.addsitedir(site_packages)
@@ -93,7 +92,9 @@ def activate_venv(venv):
 
     # Move the added items to the front of sys.path (in place!)
     new = list(sys.path)
-    sys.path[:] = [i for i in new if i not in prev] + [i for i in new if i in prev]
+    new_paths = [i for i in new if i not in prev]
+    kept_paths = [i for i in new if i in prev]
+    sys.path[:] = new_paths + kept_paths
 
 
 def inithook(venv=None):

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -11,9 +11,9 @@ import sys
 
 def is_venv():
     """Return true if a virtual environment is active."""
-    return getattr(sys, "base_prefix", sys.prefix) != sys.prefix or hasattr(
-        sys, "real_prefix"
-    )
+    is_conda_env = getattr(sys, "base_prefix", sys.prefix) != sys.prefix
+    is_virtualenv = hasattr(sys, "real_prefix")
+    return is_conda_env or is_virtualenv
 
 
 def activate_venv(active_site, venv=None):
@@ -59,5 +59,8 @@ def activate_venv(active_site, venv=None):
 
 def inithook(venv=None):
     """Activate a Virtual Environment if one is not active."""
-    if not is_venv():
-        activate_venv(site, venv)
+    if is_venv():
+        # pylint was invoked from within a venv.  Nothing to do.
+        return
+
+    activate_venv(site, venv)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,0 @@
-[metadata]
-description-file = README.rst
-
-[wheel]
-universal = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [metadata]
 description-file = README.rst
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open('README.rst') as f:
 
 setup(
     name='pylint-venv',
-    version='1.1.0',
+    version='1.2.0',
     description='pylint-venv provides a Pylint init-hook to use the same '
     'Pylint installation with different virtual environments.',
     long_description=long_description,
@@ -24,6 +24,11 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,14 @@
-#!/usr/bin/env python
+from setuptools import setup
 
-from distutils.core import setup
-
-
-with open('README.rst') as f:
-    long_description = f.read()
 
 setup(
     name='pylint-venv',
     version='1.2.0',
-    description='pylint-venv provides a Pylint init-hook to use the same '
-    'Pylint installation with different virtual environments.',
-    long_description=long_description,
+    description=(
+        'pylint-venv provides a Pylint init-hook to use the same Pylint '
+        'installation with different virtual environments.'
+    ),
+    long_description=open('README.rst').read(),
     author='Jan Gosmann, Federico Jaramillo',
     author_email='jan@hyper-world.de, federicojaramillom@gmail.com',
     url='https://github.com/jgosmann/pylint-venv/',
@@ -30,5 +27,5 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development',
-    ]
+    ],
 )


### PR DESCRIPTION
This PR contains various changes:

- Add support for Conda envs by evaluating `$CONDA_PREFIX`.
- Add support for envs using PyPy as interpreter.
- Remove modifications of `$PATH` and `$VIRTUAL_ENV`. If an env is already activated, this is not necessary, but it is also not necessary for using envs in `.venv` that are not already activated.
- Split code for env. detection and env. activation into separate functions for improved readability.
- Remove superfluous passing of the `site` module as func arg.
- Set Python 3.6 as minimum requirement (everything else IMHO doesn’t make sense in late 2019 😉 )
- In `init-hook` catch `ImportError`. Pylint-env might not be installed in virtualenv environments that have their own, local pylint installed.
- Generally improve user and developer documentation