### PR TITLE
Make pylint-venv work if pylint is installed in a different environment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.0] - 2020-03-04
 ### Added
-- Support for using pylint installed in a virtual environment. See `ignore_pylint_venv`
+- Support for using pylint installed in a virtual environment.
+See `force_venv_activation` parameter on `inithook` method.
 
 ## [2.0.0] - 2019-10-19
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2020-03-04
+### Added
+- Support for using pylint installed in a virtual environment. See `ignore_pylint_venv`
 
 ## [2.0.0] - 2019-10-19
 ### Added

--- a/README.rst
+++ b/README.rst
@@ -44,5 +44,14 @@ This way you can also explicitly set an environment to be used:
 
     $ pylint --init-hook="import pylint_venv; pylint_venv.inithook('$(pwd)/env')"
 
+If ``pylint`` itself is installed in a different virtualenv than the one you're calling it from then you can ignore it by passing ``ignore_pylint_venv=True`` as follows:
+
+.. code:: console
+
+    $ pylint --init-hook="import pylint_venv; pylint_venv.inithook(ignore_pylint_venv=True)"
+
+
+This will try to automatically detect virtualenv and activate it.
+
 .. _Pylint: http://www.pylint.org/
 .. _virtualenv: https://virtualenv.pypa.io/en/latest/

--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,12 @@ This way you can also explicitly set an environment to be used:
 
     $ pylint --init-hook="import pylint_venv; pylint_venv.inithook('$(pwd)/env')"
 
-If ``pylint`` itself is installed in a different virtualenv than the one you're calling it from then you can ignore it by passing ``ignore_pylint_venv=True`` as follows:
+If ``pylint`` itself is installed in a virtualenv, then you can ignore it by passing
+``force_venv_activation=True`` to force the activation of a different virtualenv:
 
 .. code:: console
 
-    $ pylint --init-hook="import pylint_venv; pylint_venv.inithook(ignore_pylint_venv=True)"
+    $ pylint --init-hook="import pylint_venv; pylint_venv.inithook(force_venv_activation=True)"
 
 
 This will try to automatically detect virtualenv and activate it.

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -29,6 +29,10 @@ Usage:
 
     pylint --init-hook="import pylint_venv; pylint_venv.inithook('$(pwd)/env')"
 
+- If Pylint itself is installed in a different virtualenv, to ignore that virtualenv::
+
+    pylint --init--hook="import pylint_venv; pylint_venv.inithoo(ignore_pylint_venv=True)"
+
 """
 
 import os
@@ -97,13 +101,13 @@ def activate_venv(venv):
     sys.path[:] = new_paths + kept_paths
 
 
-def inithook(venv=None):
-    """Add a virtualenv's paths to Pylint.
+def inithook(venv=None, ignore_pylint_venv=False):
+    """Add virtualenv's paths and site_packages to Pylint.
 
-    Use the environment *env* if set or auto-detect an active virtualenv.
-
+    Use environment with prefix *venv* if provided else try to auto-detect an active virtualenv.
+    Pass *ignore_pylint_venv=True* if Pylint itself is installed in a different virtualenv.
     """
-    if is_venv():
+    if not ignore_pylint_venv and is_venv():
         # pylint was invoked from within a venv.  Nothing to do.
         return
 

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -29,9 +29,10 @@ Usage:
 
     pylint --init-hook="import pylint_venv; pylint_venv.inithook('$(pwd)/env')"
 
-- If Pylint itself is installed in a different virtualenv, to ignore that virtualenv::
+- If Pylint itself is installed in a virtualenv, then you can ignore it by passing
+``force_venv_activation=True`` to force activation of a different virtualenv::
 
-    pylint --init--hook="import pylint_venv; pylint_venv.inithoo(ignore_pylint_venv=True)"
+    pylint --init--hook="import pylint_venv; pylint_venv.inithook(force_venv_activation=True)"
 
 """
 
@@ -90,13 +91,13 @@ def activate_venv(venv):
     sys.path[:] = new_paths + kept_paths
 
 
-def inithook(venv=None, ignore_pylint_venv=False):
+def inithook(venv=None, force_venv_activation=False):
     """Add virtualenv's paths and site_packages to Pylint.
 
     Use environment with prefix *venv* if provided else try to auto-detect an active virtualenv.
-    Pass *ignore_pylint_venv=True* if Pylint itself is installed in a different virtualenv.
+    Pass *force_venv_activation=True* if Pylint itself is installed in a different virtualenv.
     """
-    if not ignore_pylint_venv and is_venv():
+    if not force_venv_activation and is_venv():
         # pylint was invoked from within a venv.  Nothing to do.
         return
 

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -46,17 +46,14 @@ IS_PYPY = platform.python_implementation() == "PyPy"
 
 
 def is_venv():
-    """Return ``true`` if a virtual environment is active and Pylint is
-    installed in it.
-
-    """
+    """Return *True* if a virtual environment is currently active."""
     is_conda_env = getattr(sys, "base_prefix", sys.prefix) != sys.prefix
     is_virtualenv = hasattr(sys, "real_prefix")
     return is_conda_env or is_virtualenv
 
 
 def detect_venv():
-    # Check for a virtualenv or Conda env
+    """Check for a virtualenv or Conda env"""
     for var in ["VIRTUAL_ENV", "CONDA_PREFIX"]:
         venv = os.getenv(var, "")
         if venv:
@@ -72,15 +69,7 @@ def detect_venv():
 
 
 def activate_venv(venv):
-    """Check for an active venv and add its paths to Pylint.
-
-    Activate the virtual environment from:
-
-    - The *venv* param if one is given.
-    - ``VIRTUAL_ENV`` environmental variable if set.
-    - A ``.venv`` folder in the current working directory
-
-    """
+    """Activate the virtual environment with prefix *venv*"""
     if IS_PYPY:
         site_packages = os.path.join(venv, "site-packages")
     elif IS_WIN:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='pylint-venv',
-    version='2.0.0',
+    version='2.1.0',
     description=(
         'pylint-venv provides a Pylint init-hook to use the same Pylint '
         'installation with different virtual environments.'


### PR DESCRIPTION
The `inithook` method returns immediately if it detects that `pylint` is running inside a virtualenv. This is the typical use case.

However, there are cases when the `pylint` itself is installed in a virtualenv but is being called from a different virtualenv. For example, I am using [`coc-python`](https://github.com/neoclide/coc-python) and I have a separate `pyenv-virtualenv` for `neovim` residing in `~/.pyenv/versions/neovim`. I have `pip3 install jedi pylint black` in that virtualenv and I have hardcoded those paths in `coc-settings.json`. In this case, it is undesirable for `inithook` to return immediately.

This PR provides adds `ignore_pylint_venv=False` parameter to `inithook` method. When the argument is `True` the method does _not_ return immediately but proceeds with rest of the `inithook` logic.

The PR also updates the documentation showing how to pass the argument from a command line.