### PR TITLE
Update for different python version

### DIFF
--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -36,6 +36,7 @@ Usage:
 
 """
 
+import glob
 import os
 import platform
 import site
@@ -76,8 +77,11 @@ def activate_venv(venv):
     elif IS_WIN:
         site_packages = os.path.join(venv, "Lib", "site-packages")
     else:
-        pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
-        site_packages = os.path.join(venv, "lib", pyver, "site-packages")
+        try:
+            site_packages = glob.glob(venv + "/lib/python*/site-packages")[0]
+        except IndexError:
+            pyver = f"python{sys.version_info[0]}.{sys.version_info[1]}"
+            site_packages = os.path.join(venv, "lib", pyver, "site-packages")
 
     prev = set(sys.path)
     site.addsitedir(site_packages)


### PR DESCRIPTION
This PR can be used different python version between pylint and venv.
It's useful for pyenv user.

example by me
- pylint is installed by pipx (global python 3.6)
- pylint-venv is installed in venv of pylint
- develop library by pyenv (python 3.8)
