### PR TITLE
Allow activation of venv with version mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.egg-info/
 *.pyc
 .DS_Store
+.vscode
 MANIFEST
 build
 dist

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Activate virtual environment even if its Python version does not match the
+  Python version used by pylint. Note that Python packages in the virtual
+  environment incombatible with pylint's Python version will not work.
+
 ## [2.1.0] - 2020-03-22
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,37 +1,43 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
 ## [Unreleased]
 
 ## [2.1.0] - 2020-03-22
+
 ### Added
+
 - Support for using pylint installed in a virtual environment.
-See `force_venv_activation` parameter on `inithook` method.
+  See `force_venv_activation` parameter on `inithook` method.
 
 ## [2.0.0] - 2019-10-19
+
 ### Added
+
 - Support for Conda and PyPy
 - Documentation improvements
 
 ### Removed
+
 - Support for Python 2.7.
 
-
 ## [1.1.0] - 2019-03-26
+
 ### Added
+
 - Compatibility with Python 3 venv module.
 
-
 ## [1.0.0] - 2015-03-01
+
 ### Added
+
 - Initial release of inithook for pylint to activate virtual env.
 
-
-[Unreleased]: https://github.com/jgosmann/pylint-venv/compare/v2.0.0...HEAD
+[unreleased]: https://github.com/jgosmann/pylint-venv/compare/v2.0.0...HEAD
 [2.1.0]: https://github.com/jgosmann/pylint-venv/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/jgosmann/pylint-venv/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/jgosmann/pylint-venv/compare/v1.0.0...v1.1.0


### PR DESCRIPTION
* Figure out the proper pythonX.Y directory for the virtual environment and use that. This might not always work, e.g. if there are packages in the environment not compatible to the Python version used by pylint. However, for Windows environment and PyPy environment we already have this issue anyways.
* This is assuming that there is only ever a single pythonX.Y directory in a virtual environment. As it should be tied to a single Python version this should hold, but if not we fail instead of picking one version at random. Like the Zen of Python states: "In the face of ambiguity, refuse the temptation to guess."