### PR TITLE
Support alternate virtualenv directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Check alternative directory locations given by the `PYLINT_VENV_PATH`
+  environment variable. The variable consists of paths separated by a
+  colon `:`.
+
 ## [2.1.1] - 2020-08-17
 
 ### Fixed

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,13 @@ The hook will then be used automatically if
 
 - no env is activated but your CWD contains a virtualenv in ``.venv``
 
+  - it also reads the ``PYLINT_VENV_PATH`` environment variable for finding
+    alternative locations, e.g. for checking directories ``.venv`` and
+    ``.virtualenv``:
+      .. code:: console
+
+        PYLINT_VENV_PATH=.venv:.virtualenv
+
 and if pylint is not installed in that env, too.
 
 You can also call the hook via a command line argument:

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -65,11 +65,14 @@ def detect_venv():
         if venv:
             return venv
 
-    # Check if a local ".venv" folder exists
+    # Check if a virtualenv directory exists (.venv by default, or alternative
+    # paths given by environment variable)
+    venv_paths = os.getenv("PYLINT_VENV_PATH", ".venv").split(":")
     cwd = os.getcwd()
     exec_path = "Scripts" if IS_WIN else "bin"
-    if os.path.isfile(os.path.join(cwd, ".venv", exec_path, "activate")):
-        return os.path.join(cwd, ".venv")
+    for venv_dir in venv_paths:
+        if os.path.isfile(os.path.join(cwd, venv_dir, exec_path, "activate")):
+            return os.path.join(cwd, venv_dir)
 
     return None
 


### PR DESCRIPTION
Fix #10  

EDIT: This could be replaced by a custom environment variable, such as:
```
PYLINT_VENV_DIRECTORIES=.venv:.pyenv:.virtualenv
```