### PR TITLE
feat: add silent param to inithook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ to :code:`inithook`
 
 .. code:: console
 
-   $ pylint -f json --init-hook="import pylint_venv; pylint_venv.inithook(silent=true)"
+   $ pylint -f json --init-hook="import pylint_venv; pylint_venv.inithook(silent=True)"
 
 
 Virtual environment does not get used (installed modules are reported as 'unable to import')

--- a/README.rst
+++ b/README.rst
@@ -84,8 +84,9 @@ as pylint, or add the appropriate path in the init hook:
 pylint_vent breaks parsing with tools
 """""""""""""""""""""""""""""""""""""
 
-When tools call pylint with -f json, an extra line may break the parser, as the output is 
-no longer valid json. To avoid printing "using venv ...", pass `silent=True` to `init_hook`
+When tools call pylint with :code:`-f json`, an extra line may break the parser, as the 
+output is no longer valid json. To avoid printing "using venv ...", pass :code:`silent=True`
+to :code:`init_hook`
 
 .. code:: console
 
@@ -97,8 +98,8 @@ Virtual environment does not get used (installed modules are reported as 'unable
 
 Most likely the virtual environment does not get activated because pylint itself
 runs in a virtual environment. You can force the activation of the virtual
-environment with the `force_venv_activation=True` flag to the
-`pylint_venv.inithook` function.
+environment with the :code:`force_venv_activation=True` flag to the
+:code:`pylint_venv.inithook` function.
 
 
 Homebrew

--- a/README.rst
+++ b/README.rst
@@ -85,12 +85,12 @@ pylint_vent breaks parsing with tools
 """""""""""""""""""""""""""""""""""""
 
 When tools call pylint with :code:`-f json`, an extra line may break the parser, as the 
-output is no longer valid json. To avoid printing "using venv ...", pass :code:`silent=True`
+output is no longer valid json. To avoid printing "using venv ...", pass :code:`quiet=True`
 to :code:`inithook`
 
 .. code:: console
 
-   $ pylint -f json --init-hook="import pylint_venv; pylint_venv.inithook(silent=True)"
+   $ pylint -f json --init-hook="import pylint_venv; pylint_venv.inithook(quiet=True)"
 
 
 Virtual environment does not get used (installed modules are reported as 'unable to import')

--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ pylint_vent breaks parsing with tools
 
 When tools call pylint with :code:`-f json`, an extra line may break the parser, as the 
 output is no longer valid json. To avoid printing "using venv ...", pass :code:`silent=True`
-to :code:`init_hook`
+to :code:`inithook`
 
 .. code:: console
 

--- a/README.rst
+++ b/README.rst
@@ -81,6 +81,17 @@ as pylint, or add the appropriate path in the init hook:
     sys.path.append("/path/to/installation/folder/of/pylint_venv")
 
 
+pylint_vent breaks parsing with tools
+"""""""""""""""""""""""""""""""""""""
+
+When tools call pylint with -f json, an extra line may break the parser, as the output is 
+no longer valid json. To avoid printing "using venv ...", pass `silent=True` to `init_hook`
+
+.. code:: console
+
+   $ pylint -f json --init-hook="import pylint_venv; pylint_venv.inithook(silent=true)"
+
+
 Virtual environment does not get used (installed modules are reported as 'unable to import')
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -108,7 +108,7 @@ def activate_venv(venv):
     sys.path[:] = new_paths + kept_paths
 
 
-def inithook(venv=None, force_venv_activation=False):
+def inithook(venv=None, force_venv_activation=False, silent=False):
     """Add virtualenv's paths and site_packages to Pylint.
 
     Use environment with prefix *venv* if provided else try to auto-detect an active virtualenv.
@@ -124,5 +124,6 @@ def inithook(venv=None, force_venv_activation=False):
     if venv is None:
         return
 
-    print(f"Using env: {venv}", file=sys.stderr)
+    if not silent:
+        print(f"Using env: {venv}", file=sys.stderr)
     activate_venv(venv)

--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -108,7 +108,7 @@ def activate_venv(venv):
     sys.path[:] = new_paths + kept_paths
 
 
-def inithook(venv=None, force_venv_activation=False, silent=False):
+def inithook(venv=None, force_venv_activation=False, quiet=False):
     """Add virtualenv's paths and site_packages to Pylint.
 
     Use environment with prefix *venv* if provided else try to auto-detect an active virtualenv.
@@ -124,6 +124,6 @@ def inithook(venv=None, force_venv_activation=False, silent=False):
     if venv is None:
         return
 
-    if not silent:
+    if not quiet:
         print(f"Using env: {venv}", file=sys.stderr)
     activate_venv(venv)


### PR DESCRIPTION
The easiest way to parse pylint output is with `-f json`, but calling `inithook()` breaks the JSON parser by adding the extra "Using <> env".

The PR adds a `silent` parameter which, if `True`, will make `inithook` avoid printing that line