### PR TITLE
Clarify that configuration must come under [MASTER]

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,7 @@ Add the following to your ``~/.pylintrc``:
 
 .. code:: ini
 
+    [MASTER]
     init-hook=
         try: import pylint_venv
         except ImportError: pass
@@ -113,6 +114,7 @@ Python version:
 
 .. code:: ini
 
+    [MASTER]
     init-hook=
         import sys
         sys.path.append("/usr/local/lib/python3.8/site-packages")


### PR DESCRIPTION
I couldn't get the configuration to work, until I realised that I needed to have `[MASTER]` in the configuration file `.pylintrc`