### PR TITLE
Make the automated test work without which(1)

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -3,10 +3,9 @@
 set -o errexit -o nounset -o pipefail -o xtrace
 
 WORKDIR=$(dirname "$0")
-PYLINT_CMD=$(which pylint)
 VENV_DIR=$(mktemp -d)
 
 python3 -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
-"$PYLINT_CMD" --rcfile "$WORKDIR/pylintrc" "$WORKDIR/empty.py" 2>&1 | tee "$VENV_DIR/pylint.log" | grep "^Using venv: $VENV_DIR\$"
+pylint --rcfile "$WORKDIR/pylintrc" "$WORKDIR/empty.py" 2>&1 | tee "$VENV_DIR/pylint.log" | grep "^Using venv: $VENV_DIR\$"
 rm -r "$VENV_DIR"


### PR DESCRIPTION
which(1) is a third-party executable that's not installed on every system out there, and it is entirely redundant to shell builtins such as `command -v` (POSIX sh) or `type -P` (bash).  Since there does not seem to be any real need to use full path here, just inline the `pylint` call.