### PR TITLE
Fix error in Conda environments that use Python 3.10

### DIFF
--- a/pylint_venv.py
+++ b/pylint_venv.py
@@ -86,6 +86,10 @@ def activate_venv(venv):
     else:
         lib_dir = os.path.join(venv, "lib")
         python_dirs = [d for d in os.listdir(lib_dir) if re.match(r"python\d+.\d+", d)]
+
+        # Resolve symlinks and remove repeated directories
+        python_dirs = set([os.path.realpath(os.path.join(lib_dir, d)) for d in python_dirs])
+
         if len(python_dirs) == 0:
             raise IncompatibleVenvError(
                 f"The virtual environment {venv!r} is missing a lib/pythonX.Y directory."
@@ -94,7 +98,7 @@ def activate_venv(venv):
             raise IncompatibleVenvError(
                 f"The virtual environment {venv!r} has multiple lib/pythonX.Y directories."
             )
-        site_packages = os.path.join(lib_dir, python_dirs[0], "site-packages")
+        site_packages = os.path.join(list(python_dirs)[0], "site-packages")
 
     prev = set(sys.path)
     site.addsitedir(site_packages)


### PR DESCRIPTION
First of all, thanks for this great package! We're using it in [Spyder](https://github.com/spyder-ide/spyder) to easily run Pylint in any virtual or conda environment.

This PR will solve [an error](https://github.com/spyder-ide/spyder/issues/20602) discovered by our users in Python 3.10 conda envs for Posix systems. It seems in that case conda automatically creates a symlink called `python3.1`, which points to the `python3.10` directory. To avoid it, I resolved all symlinks for Python directories found by `pylint_env` and discarded the repeated ones.